### PR TITLE
fixed unit number in range 100-102

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,8 @@ ELSEIF(${CMAKE_Fortran_COMPILER_ID} MATCHES "GNU")
     SET(TOOL_CHAIN "gfort")
 ELSEIF(${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel")
     SET(TOOL_CHAIN "ifort")
+ELSE()
+    SET(TOOL_CHAIN "${CMAKE_Fortran_COMPILER_ID}")
 ENDIF()
 
 ### Break in case of popular CMake configuration mistakes.
@@ -101,7 +103,6 @@ INCLUDE(SetFortranFlags)
 OPTION(USE_MPI "Use the MPI library for parallelization" OFF)
 OPTION(USE_OPENMP "Use OpenMP for parallelization" OFF)
 INCLUDE(SetParallelizationLibrary)
-
 ### Use statically or dynamically linkage?
 ### Global flag to cause add_library to create shared libraries if on, otherwise static library.
 OPTION(BUILD_SHARED_LIBS "Build shared libraries (DLLs)." OFF)

--- a/src/openwth.f
+++ b/src/openwth.f
@@ -59,14 +59,14 @@
         end if
         if (rfile(j) /= '             ') then
      !!     open (100+j,file=rfile(j),recl=800)
-          open (100+j,file=rfile(j),recl=1850)
-          read (100+j,5000) titldum
-          read (100+j,5000) titldum
-          read (100+j,5000) titldum
+          open (1000+j,file=rfile(j),recl=1850)
+          read (1000+j,5000) titldum
+          read (1000+j,5000) titldum
+          read (1000+j,5000) titldum
           if (ievent == 0) then   !daily records
-            read (100+j,5001) (elevp(k), k = kk1, kk2)
+            read (1000+j,5001) (elevp(k), k = kk1, kk2)
           else                   !subdaily records
-            read (100+j,5003) (elevp(k), k = kk1, kk2)
+            read (1000+j,5003) (elevp(k), k = kk1, kk2)
           endif
         end if
       end do

--- a/src/pmeas.f
+++ b/src/pmeas.f
@@ -118,13 +118,13 @@
 
             !! read data from file
             if (ifirstpcp(k) == 0) then
-              read (100+k,5000) (rmeas(l), l = kk1, kk2)
+              read (1000+k,5000) (rmeas(l), l = kk1, kk2)
             else
               ifirstpcp(k) = 0
               do
                 iyp = 0
                 idap = 0
-                read (100+k,5100) iyp, idap, (rmeas(l), l = kk1, kk2)
+                read (1000+k,5100) iyp, idap, (rmeas(l), l = kk1, kk2)
                 if (iyp + idap <= 0) exit
                 if (iyp == iyr .and. idap == id1) exit
               end do
@@ -181,15 +181,15 @@
 
             !! read data from file
             if (ifirstpcp(k) == 0) then
-              read (100+k,5300) a
-              backspace (100+k)
+              read (1000+k,5300) a
+              backspace (1000+k)
               if (a /= " ") then               !subdaily precip on day
                 do ii = 1, nstep
                   flag = 0
                   ihour = 0
                   imin = 0
                   a = ""
-                  read (100+k,5200) iyp, idap, ihour, imin,             
+                  read (1000+k,5200) iyp, idap, ihour, imin,             
      &                                      (rainsb(l,ii), l = kk1, kk2)
 				   if (iyp /= iyr .or. idap /= i) flag = 1
                   if (flag == 1) then
@@ -205,7 +205,7 @@
                   end do
                 end do
               else                                 !no precip on day
-                read (100+k,5201) iyp, idap, (rmeas(l), l = kk1, kk2)
+                read (1000+k,5201) iyp, idap, (rmeas(l), l = kk1, kk2)
                   if (iyp /= iyr .or. idap /= i) flag = 1
                   if (flag == 1) then
                     write (24,5400) iyr, i
@@ -224,7 +224,7 @@
               do
                 iyp = 0
                 idap = 0
-                read (100+k,5202) iyp, idap, ihour, a, imin,            
+                read (1000+k,5202) iyp, idap, ihour, a, imin,            
      &                                       (rainsb(l,1), l = kk1, kk2)
                 if (iyp == iyr .and. idap == i) flag = 1
                 if (flag == 1) then
@@ -239,7 +239,7 @@
                     do ii = 2, nstep
                       ihour = 0
                       imin = 0
-                      read (100+k,5200) iyp, idap, ihour, imin,         
+                      read (1000+k,5200) iyp, idap, ihour, imin,         
      &                                      (rainsb(l,ii), l = kk1, kk2)
                       do l = kk1, kk2
                         if (rainsb(l,1)<-97) then

--- a/src/readbsn.f
+++ b/src/readbsn.f
@@ -698,7 +698,7 @@
 
       call caps(petfile)
       call caps(wwqfile)
-      open (101,file=wwqfile)
+      open (91,file=wwqfile)
 
 !!    calculate normalization parameters for water, nitrogen, and
 !!    phosphorus uptake

--- a/src/readfig.f
+++ b/src/readfig.f
@@ -197,7 +197,7 @@
               i = 0
               i = inum1s(idum)
               subed(ihouts(idum)) = inum4s(idum)
-              open (101,file=subfile)
+              open (91,file=subfile)
               call readsub
               nhru = nhru + hrutot(i)
 

--- a/src/readfig.f
+++ b/src/readfig.f
@@ -131,18 +131,18 @@
 
       do 
         a = ""
-        read (102,5002,iostat=eof) a
+        read (92,5002,iostat=eof) a
         if (eof < 0) exit
         if (a /= "*") then
-          backspace 102
+          backspace 92
           idum = idum + 1
 
 !!    CEAP project
         if (isproj == 2) then
-          read (102,5003) a, icodes(idum), ihouts(idum), inum1s(idum),  
+          read (92,5003) a, icodes(idum), ihouts(idum), inum1s(idum),  
      &    inum2s(idum), inum3s(idum), rnum1s(idum), inum4s(idum)
 	  else
-          read (102,5000) a, icodes(idum), ihouts(idum), inum1s(idum),  
+          read (92,5000) a, icodes(idum), ihouts(idum), inum1s(idum),  
      &    inum2s(idum), inum3s(idum), rnum1s(idum), inum4s(idum),       
  !!    &    inum5s(idum), inum6s(idum), inum7s(idum), inum8s(idum)
      &    inum5s(idum), char6(idum), char7(idum), char8(idum)
@@ -192,7 +192,7 @@
               subtot = subtot + 1
               subgis(inum1s(idum)) = inum4s(idum)
               subfile = ""
-              read (102,5100) subfile
+              read (92,5100) subfile
               call caps(subfile)
               i = 0
               i = inum1s(idum)
@@ -209,7 +209,7 @@
               end if  
               rtefile = ""
               swqfile = ""
-              read (102,5100) rtefile, swqfile
+              read (92,5100) rtefile, swqfile
               call caps(rtefile)
               call caps(swqfile)
               irch = 0
@@ -223,7 +223,7 @@
               nres = nres + 1
               resfile = ""
               lwqfile = ""
-              read (102,5100) resfile, lwqfile
+              read (92,5100) resfile, lwqfile
               call caps(resfile)
               call caps(lwqfile)
               i = 0
@@ -238,14 +238,14 @@
               call lwqdef
  
             case (4)  !! icode = 4  TRANSFER command: read in beg/end month
-              read (102,5004) mo_transb(inum5s(idum)),    
+              read (92,5004) mo_transb(inum5s(idum)),    
      &		    mo_transe(inum5s(idum)), ih_tran(inum5s(idum))
 
 
             case (6)  !! icode = 6  RECHOUR command: read in hourly values
                       !! with water in m^3 and rest in tons/kgs
               hour_in = ""
-              read (102,5100) hour_in
+              read (92,5100) hour_in
               call caps(hour_in)
               open (200+inum1s(idum),file=hour_in,recl=350)
               do ii = 1, 6
@@ -255,7 +255,7 @@
             case (7)  !! icode = 7  RECMON command:
                       !!  read in monthly values
             month_in = ""
-            read (102,5100) month_in
+            read (92,5100) month_in
               recmonps(ihouts(idum)) = month_in(1:index(month_in,'.')-1)
             call caps(month_in)
             i = 0
@@ -266,7 +266,7 @@
             case (8)  !! icode = 8  RECYEAR command: 
                       !! read in average daily loadings for each year
             year_in = ""
-            read (102,5100) year_in
+            read (92,5100) year_in
             
             call caps(year_in)
             i = 0
@@ -280,7 +280,7 @@
                       !! constituent masses from a hydrograph node on
                       !! the channel network to an output file 
               day_in = ""
-              read (102,5100) day_in
+              read (92,5100) day_in
               call caps(day_in)
               if (inum1s(idum) <= 10 .and. inum1s(idum) > 0) then
                 open (40+inum1s(idum),file=day_in,recl=350)
@@ -299,7 +299,7 @@
             case (10) !! icode = 10  RECDAY command: read in daily values
                       !! with water in cms and rest in tons
               day_in = ""
-              read (102,5100) day_in
+              read (92,5100) day_in
               call caps(day_in)
               open (555+inum1s(idum),file=day_in,recl=350)
               do ii = 1, 6
@@ -310,7 +310,7 @@
                       !! annual values with water in m^3, sed in t, and 
                       !! the nutrients in kg
             annual_in = ""
-            read (102,5100) annual_in
+            read (92,5100) annual_in
             reccnstps(ihouts(idum))=annual_in(1:index(annual_in,'.')-1)
             call caps(annual_in)
             i = 0
@@ -321,7 +321,7 @@
 !! code to read from apex output file
             case (13) 
             apex_in = ""
-            read (102,5100) apex_in
+            read (92,5100) apex_in
 	      call caps(apex_in)
       !      i = 0
       !      i = inum1s(idum)
@@ -337,7 +337,7 @@
                       !! output file from a hydrograph node on the 
                       !! channel network
               day_in = ""
-              read (102,5100) day_in
+              read (92,5100) day_in
               call caps(day_in)
               if (inum1s(idum) <= 50 .and. inum1s(idum) > 0) then
                 open (50+inum1s(idum),file=day_in,recl=350)
@@ -347,7 +347,7 @@
 
             case (17)  !! icode = 17  ROUTING UNIT command
               rufile = ""
-              read (102,5100) rufile
+              read (92,5100) rufile
               call caps(rufile)
               iru = inum1s(idum)
               isub = inum2s(idum)
@@ -393,7 +393,7 @@
       end do
 
 !! close .fig file
-      close (102)
+      close (92)
 
 
       return

--- a/src/readfile.f
+++ b/src/readfile.f
@@ -154,7 +154,7 @@
       read (91,*) idal
 
       call caps(figfile)
-      open (102,file=figfile)
+      open (92,file=figfile)
 
 !! Read climate information
       read (91,5101) titldum

--- a/src/readfile.f
+++ b/src/readfile.f
@@ -138,55 +138,55 @@
       urbandb = ""
       septdb = ""   !!SEPTIC CHANGES GSM 1/30/09
 
-      open (101,file="file.cio")
+      open (91,file="file.cio")
 
 !! Read project description
-      read (101,5101) titldum
-      read (101,5101) titldum
-      read (101,5100) title
+      read (91,5101) titldum
+      read (91,5101) titldum
+      read (91,5100) title
 
 !! Read general information/watershed configuration
-      read (101,5101) titldum
-      read (101,5000) figfile
-      read (101,*) nbyr
-      read (101,*) iyr
-      read (101,*) idaf
-      read (101,*) idal
+      read (91,5101) titldum
+      read (91,5000) figfile
+      read (91,*) nbyr
+      read (91,*) iyr
+      read (91,*) idaf
+      read (91,*) idal
 
       call caps(figfile)
       open (102,file=figfile)
 
 !! Read climate information
-      read (101,5101) titldum
-      read (101,*) igen
-      read (101,*) pcpsim
-      read (101,*) idt
-      read (101,*) idist
-      read (101,*) rexp
-      read (101,*) nrgage
-      read (101,*) nrtot
-      read (101,*) nrgfil
-      read (101,*) tmpsim
-      read (101,*) ntgage
-      read (101,*) nttot
-      read (101,*) ntgfil
-      read (101,*) slrsim
-      read (101,*) nstot
-      read (101,*) rhsim
-      read (101,*) nhtot
-      read (101,*) wndsim
-      read (101,*) nwtot
-      read (101,*) fcstyr
-      read (101,*) fcstday
-      read (101,*) fcstcycles
-      read (101,5101) titldum
-      read (101,5000) (rfile(j),j = 1,18)
-      read (101,5101) titldum
-      read (101,5000) (tfile(j),j = 1,18)
-      read (101,5000) slrfile
-      read (101,5000) rhfile
-      read (101,5000) wndfile
-      read (101,5000) fcstfile
+      read (91,5101) titldum
+      read (91,*) igen
+      read (91,*) pcpsim
+      read (91,*) idt
+      read (91,*) idist
+      read (91,*) rexp
+      read (91,*) nrgage
+      read (91,*) nrtot
+      read (91,*) nrgfil
+      read (91,*) tmpsim
+      read (91,*) ntgage
+      read (91,*) nttot
+      read (91,*) ntgfil
+      read (91,*) slrsim
+      read (91,*) nstot
+      read (91,*) rhsim
+      read (91,*) nhtot
+      read (91,*) wndsim
+      read (91,*) nwtot
+      read (91,*) fcstyr
+      read (91,*) fcstday
+      read (91,*) fcstcycles
+      read (91,5101) titldum
+      read (91,5000) (rfile(j),j = 1,18)
+      read (91,5101) titldum
+      read (91,5000) (tfile(j),j = 1,18)
+      read (91,5000) slrfile
+      read (91,5000) rhfile
+      read (91,5000) wndfile
+      read (91,5000) fcstfile
  
       !! calculate precipitation data lines per day
       if (idt > 0) nstep = 1440 / idt
@@ -248,19 +248,19 @@
       end if
 
 !!Open watershed modeling option file
-      read (101,5101) titldum
-      read (101,5000) bsnfile
+      read (91,5101) titldum
+      read (91,5000) bsnfile
 
       call caps(bsnfile)
       open (103,file=bsnfile)
 
 !!Open database files
-      read (101,5101) titldum
-      read (101,5000) plantdb
-      read (101,5000) tilldb
-      read (101,5000) pestdb
-      read (101,5000) fertdb
-      read (101,5000) urbandb
+      read (91,5101) titldum
+      read (91,5000) plantdb
+      read (91,5000) tilldb
+      read (91,5000) pestdb
+      read (91,5000) fertdb
+      read (91,5000) urbandb
 
       call caps(plantdb)
       call caps(tilldb)
@@ -275,21 +275,21 @@
 	
 
 !!Special Projects input
-      read (101,5101) titldum
-      read (101,*) isproj
-      read (101,*) iclb
-      read (101,5000) calfile
+      read (91,5101) titldum
+      read (91,*) isproj
+      read (91,*) iclb
+      read (91,5000) calfile
 
 !!Output Information input
-      read (101,5101) titldum
-      read (101,*) iprint
-      read (101,*) nyskip
+      read (91,5101) titldum
+      read (91,*) iprint
+      read (91,*) nyskip
 !!! check that nyskip input is not greater or equal to nbyr input
       if (nyskip >= nbyr) nyskip = nbyr - 1
       
-      read (101,*) ilog
-      read (101,*) iprp
-      read (101,5101) titldum
+      read (91,*) ilog
+      read (91,*) iprp
+      read (91,5101) titldum
 
       !!The user has the option of limiting the number of output
       !!variables printed to the output.rch, output.sub and 
@@ -299,8 +299,8 @@
 
       !!Output variables printed in REACH (output.rch) file
 
-      read (101,5101) titldum
-      read (101,*) (ipdvar(ii),ii=1,20)
+      read (91,5101) titldum
+      read (91,*) (ipdvar(ii),ii=1,20)
 
       !!IPDVAR  - Output variables to output.rch file
              !![   1] Streamflow into reach (cms)
@@ -355,8 +355,8 @@
 
       !!Output variables printed in SUBASIN (output.sub) file
 
-      read (101,5101) titldum
-      read (101,*) (ipdvab(ii),ii=1,15)
+      read (91,5101) titldum
+      read (91,*) (ipdvab(ii),ii=1,15)
 
       !!IPDVAB  - Output variables to output.sub file
              !![   1] Total precipitation falling on subbasin (mm)
@@ -377,8 +377,8 @@
 
       !!Output variables printed in HRU (output.hru) file
 
-      read (101,5101) titldum
-      read (101,*) (ipdvas(ii),ii=1,20)
+      read (91,5101) titldum
+      read (91,*) (ipdvas(ii),ii=1,20)
 
       !!IPDVAS  - Output variables to output.hru file
              !![   1] Total precipitation falling on HRU (mm)
@@ -461,14 +461,14 @@
 
       !!HRUs printed in HRU (output.hru,output.wtr) files
 
-      read (101,5101) titldum
-      read (101,*) (ipdhru(ii),ii=1,20)
+      read (91,5101) titldum
+      read (91,*) (ipdhru(ii),ii=1,20)
 
       !! Atmospheric deposition file (Kannan/Santhi input file)
       do
-       read (101,5101,iostat=eof) titldum
+       read (91,5101,iostat=eof) titldum
        if (eof < 0) exit
-       read (101,5000,iostat=eof) atmofile
+       read (91,5000,iostat=eof) atmofile
        if (eof < 0) exit
        exit
       end do
@@ -477,18 +477,18 @@
 !!   IPHR = 0 no print
 !!   IPHR = 1 print file
       iphr = 0
-      read (101,*,iostat=eof) iphr
+      read (91,*,iostat=eof) iphr
 !!   code for printing soil storage values by soil layer (output.swr)
 !!   ISTO = 0 no print
 !!   ISTO = 1 print file
       isto = 0
-      read (101,*,iostat=eof) isto
+      read (91,*,iostat=eof) isto
 
 !!   code for printing output.sol file (formerly 'output.sol' - now output.snu)
 !!   isol = 0 no print
 !!   isol = 1 print file
       isol = 0
-      read (101,*,iostat=eof) isol  
+      read (91,*,iostat=eof) isol  
       if (isol == 1) then
          open (121,file='output.snu')
          write (121,12222) 
@@ -500,12 +500,12 @@
       end if  
 !! headwater code (0=do not route; 1=route)
       i_subhw = 0
-      read (101,*,iostat=eof) i_subhw 
+      read (91,*,iostat=eof) i_subhw 
 
 !! SEPTIC CHANGES GSM 01/29/09
 !!   gsm had to take do off when added ia_b ??? 3/25/09 for binary files
 !!      do
-      read (101,5000,iostat=eof) septdb
+      read (91,5000,iostat=eof) septdb
 !!      if (eof < 0) exit
       call caps(septdb)
 !!	end do
@@ -518,22 +518,22 @@
 !!       0 for ascii file 
 !!       1 for binary file   
       ia_b = 0  
-      read (101, *, iostat=eof) ia_b
+      read (91, *, iostat=eof) ia_b
 
 !!    read code to turn on output.wqr output file
 !!      ihumus = 0 (do not print file)
 !!      ihumus = 1 (print formerly watqual.out - now output.wql)
-      read(101,*,iostat=eof) ihumus
+      read (91,*,iostat=eof) ihumus
 
 
 !!   flag for output files named tempvel.out and tempdep.out
 !!   this flag will print both files 
 !!   default is = 0; no print
-      read (101,*,iostat=eof) itemp
+      read (91,*,iostat=eof) itemp
 
 
 !!    output by elevation band to (formerly 'snowband.out')
-      read (101,*,iostat=eof) isnow
+      read (91,*,iostat=eof) isnow
 	if (isnow == 1) then
          open (115,file='output.snw')
          write (115,1010)
@@ -689,7 +689,7 @@
 
 !! Code for output.mgt file
 !  0=no print 1=print
-      read (101, *,iostat=eof) imgt
+      read (91, *,iostat=eof) imgt
 	if (imgt==1) then
          open (143, file="output.mgt", recl=600)
          write (143,999)
@@ -717,7 +717,7 @@
       
 !! Code for output.wtr and output.pot files
 ! 0 =no print  1 =print
-      read (101,*,iostat=eof) iwtr
+      read (91,*,iostat=eof) iwtr
         if (iwtr == 1) then
           open (29,file="output.wtr",recl=800)
 ! write statement added for Aziz (06/25/09)
@@ -734,7 +734,7 @@
 !     code for writing out calendar day or julian day to output.rch, .sub, .hru files
 !     icalen = 0 (print julian day) 1 (print month/day/year)
 !     icalen MUST be == zero  if IPRINT == 3 to print subdaily;
-      read (101,*, iostat=eof) icalen
+      read (91,*, iostat=eof) icalen
       if (icalen == 1) iprint = 1
       
       if (isproj == 1) then
@@ -762,7 +762,7 @@
 !     & 6x,'conc_n',4x,'con_nirr',6x,'nsetlr',5x,'theta_n',7x,'tmpav',
 !     & 6x,'nitrok',/,15x,'m3',12x,'kg',12x,'ha',9x,'kg/m3',5x,'kg/m3',
 !     & 9x,'--',9x,'--',12x,'deg c',6x,'--')
-      close (101)
+      close (91)
       return
 
  1010 format (32x,'SNOW(mm) at ELEVATION BAND (1-10)',/,                

--- a/src/readres.f
+++ b/src/readres.f
@@ -331,17 +331,17 @@
 !! read in monthly release data
       if (iresco(i) == 1) then
         call caps(resmono)
-        open (101,file=resmono)
-        read (101,1000) titldum
+        open (91,file=resmono)
+        read (91,1000) titldum
           do j = 1, nbyr+2
-            read (101,*,iostat=eof) (res_out(i,mon,j), mon = 1, 12)
+            read (91,*,iostat=eof) (res_out(i,mon,j), mon = 1, 12)
             if (eof < 0) exit
             do mon = 1, 12
               !! convert m**3/s => m**3/day
               res_out(i,mon,j) = res_out(i,mon,j) * 86400.
             end do
           end do
-        close (101)
+        close (91)
       end if
 
       close (105)

--- a/src/readsub.f
+++ b/src/readsub.f
@@ -152,10 +152,10 @@
       if = 0
       ir = 0
 
-      read (101,5100) titldum
-      read (101,*) sub_km(i)
+      read (91,5100) titldum
+      read (91,*) sub_km(i)
       if (isproj == 3) then
-       read (101,5101) harg_petco(i), cncoef_sub(i), sub_smfmx(1,i),
+       read (91,5101) harg_petco(i), cncoef_sub(i), sub_smfmx(1,i),
      &  sub_smfmn(1,i), sub_sftmp(1,i), sub_smtmp(1,i), sub_timp(1,i)
         do ib = 2, 10
           sub_smfmx(ib,i) = sub_smfmx(1,i)
@@ -165,45 +165,45 @@
           sub_timp(ib,i) = sub_timp(1,i)
         end do
       else
-        read (101,5100) titldum                                      
+        read (91,5100) titldum                                      
       end if
-      read (101,5100) titldum
-      read (101,*) sub_lat(i)
-      read (101,*) sub_elev(i)
-      read (101,*) irgage(i)
-      read (101,*) itgage(i)
-      read (101,*) isgage(i)
-      read (101,*) ihgage(i)
-      read (101,*) iwgage(i)
-      read (101,5300) wgnfile
+      read (91,5100) titldum
+      read (91,*) sub_lat(i)
+      read (91,*) sub_elev(i)
+      read (91,*) irgage(i)
+      read (91,*) itgage(i)
+      read (91,*) isgage(i)
+      read (91,*) ihgage(i)
+      read (91,*) iwgage(i)
+      read (91,5300) wgnfile
         call caps(wgnfile)
         open (114,file=wgnfile)
-      read (101,*) fcst_reg(i)
-      read (101,5100) titldum
-      read (101,5100) titldum
-      read (101,5200) (elevb(j,i), j = 1, 10)
-      read (101,5100) titldum
-      read (101,5200) (elevb_fr(j,i), j = 1, 10)
-      read (101,5100) titldum
-      read (101,5200) (ssnoeb(j), j = 1, 10)
-      read (101,*) plaps(i)
-      read (101,*) tlaps(i) 
-      read (101,*) sno_sub
-      read (101,5100) titldum
-      read (101,*) ch_ls
-      read (101,*) ch_s(1,i)
-      read (101,*) ch_w(1,i)
-      read (101,*) ch_k(1,i)
-      read (101,*) ch_n(1,i)
-      read (101,5100) titldum
-      read (101,5300) pndfile
+      read (91,*) fcst_reg(i)
+      read (91,5100) titldum
+      read (91,5100) titldum
+      read (91,5200) (elevb(j,i), j = 1, 10)
+      read (91,5100) titldum
+      read (91,5200) (elevb_fr(j,i), j = 1, 10)
+      read (91,5100) titldum
+      read (91,5200) (ssnoeb(j), j = 1, 10)
+      read (91,*) plaps(i)
+      read (91,*) tlaps(i) 
+      read (91,*) sno_sub
+      read (91,5100) titldum
+      read (91,*) ch_ls
+      read (91,*) ch_s(1,i)
+      read (91,*) ch_w(1,i)
+      read (91,*) ch_k(1,i)
+      read (91,*) ch_n(1,i)
+      read (91,5100) titldum
+      read (91,5300) pndfile
         call caps(pndfile)
         open (104,file=pndfile)
-      read (101,5100) titldum
-      read (101,5300) wusfile
+      read (91,5100) titldum
+      read (91,5300) wusfile
         call caps(wusfile)
         open (105,file=wusfile)
-      read (101,5100) snofile
+      read (91,5100) snofile
       if(snofile /='             ' .or. snofile /= 'Climate Change')then
         if (snofile /='             ') then
           if (snofile /= 'Climate Change') then
@@ -213,35 +213,35 @@
           endif
         endif
       endif
-      read (101,*) co2(i) 
-      read (101,5100) titldum
-      read (101,5200) (rfinc(i,mon),mon = 1,6)
-      read (101,5100) titldum
-      read (101,5200) (rfinc(i,mon),mon = 7,12)
-      read (101,5100) titldum
-      read (101,5200) (tmpinc(i,mon),mon = 1,6)
-      read (101,5100) titldum
-      read (101,5200) (tmpinc(i,mon),mon = 7,12)
-      read (101,5100) titldum
-      read (101,5200) (radinc(i,mon),mon = 1,6)
-      read (101,5100) titldum
-      read (101,5200) (radinc(i,mon),mon = 7,12)
-      read (101,5100) titldum
-      read (101,5200) (huminc(i,mon),mon = 1,6)
-      read (101,5100) titldum
-      read (101,5200) (huminc(i,mon),mon = 7,12)
-      read (101,5100) titldum
+      read (91,*) co2(i) 
+      read (91,5100) titldum
+      read (91,5200) (rfinc(i,mon),mon = 1,6)
+      read (91,5100) titldum
+      read (91,5200) (rfinc(i,mon),mon = 7,12)
+      read (91,5100) titldum
+      read (91,5200) (tmpinc(i,mon),mon = 1,6)
+      read (91,5100) titldum
+      read (91,5200) (tmpinc(i,mon),mon = 7,12)
+      read (91,5100) titldum
+      read (91,5200) (radinc(i,mon),mon = 1,6)
+      read (91,5100) titldum
+      read (91,5200) (radinc(i,mon),mon = 7,12)
+      read (91,5100) titldum
+      read (91,5200) (huminc(i,mon),mon = 1,6)
+      read (91,5100) titldum
+      read (91,5200) (huminc(i,mon),mon = 7,12)
+      read (91,5100) titldum
 !! read HRU input data
-      read (101,*) hrutot(i)
-      read (101,5100) titldum
-      read (101,5100) titldum
-      read (101,5100) titldum
-      read (101,5100) titldum
-      read (101,5100) titldum
-      read (101,5100) titldum
-      read (101,5100) titldum
+      read (91,*) hrutot(i)
+      read (91,5100) titldum
+      read (91,5100) titldum
+      read (91,5100) titldum
+      read (91,5100) titldum
+      read (91,5100) titldum
+      read (91,5100) titldum
+      read (91,5100) titldum
       !!General HRUs
-      read (101,5100) titldum
+      read (91,5100) titldum
         do j = jj, hrutot(i)
           ihru = 0
           ihru = nhru + j
@@ -257,7 +257,7 @@
           opsfile = ""
           septfile = ""
           sdrfile = ""
-         read (101,5300) hrufile, mgtfile, solfile, chmfile, gwfile,
+         read (91,5300) hrufile, mgtfile, solfile, chmfile, gwfile,
      & opsfile, septfile, sdrfile, ils2(ihru)
           call caps(hrufile)
           call caps(mgtfile)
@@ -463,7 +463,7 @@
 	dratio(i) = 0.42 * sub_km(i) ** (-0.125)
 	if(dratio(i)>0.9) dratio(i) = 0.9
 
-      close (101)
+      close (91)
       return
  1000 format ('ERROR: Elevation Band Fractions in Subbasin ',i4,        
      &        ' do not add up to 100% of subbasin area!')

--- a/src/readwwq.f
+++ b/src/readwwq.f
@@ -75,47 +75,47 @@
       eof = 0
 
       do
-      read (101,5100,iostat=eof) titldum
+      read (91,5100,iostat=eof) titldum
       if (eof < 0) exit
-      read (101,*,iostat=eof) lao 
+      read (91,*,iostat=eof) lao 
       if (eof < 0) exit
-      read (101,*,iostat=eof) igropt 
+      read (91,*,iostat=eof) igropt 
       if (eof < 0) exit
-      read (101,*,iostat=eof) ai0 
+      read (91,*,iostat=eof) ai0 
       if (eof < 0) exit
-      read (101,*,iostat=eof) ai1 
+      read (91,*,iostat=eof) ai1 
       if (eof < 0) exit
-      read (101,*,iostat=eof) ai2 
+      read (91,*,iostat=eof) ai2 
       if (eof < 0) exit
-      read (101,*,iostat=eof) ai3 
+      read (91,*,iostat=eof) ai3 
       if (eof < 0) exit
-      read (101,*,iostat=eof) ai4
+      read (91,*,iostat=eof) ai4
       if (eof < 0) exit
-      read (101,*,iostat=eof) ai5 
+      read (91,*,iostat=eof) ai5 
       if (eof < 0) exit
-      read (101,*,iostat=eof) ai6 
+      read (91,*,iostat=eof) ai6 
       if (eof < 0) exit
-      read (101,*,iostat=eof) mumax 
+      read (91,*,iostat=eof) mumax 
       if (eof < 0) exit
-      read (101,*,iostat=eof) rhoq 
+      read (91,*,iostat=eof) rhoq 
       if (eof < 0) exit
-      read (101,*,iostat=eof) tfact 
+      read (91,*,iostat=eof) tfact 
       if (eof < 0) exit
-      read (101,*,iostat=eof) k_l 
+      read (91,*,iostat=eof) k_l 
       if (eof < 0) exit
-      read (101,*,iostat=eof) k_n 
+      read (91,*,iostat=eof) k_n 
       if (eof < 0) exit
-      read (101,*,iostat=eof) k_p 
+      read (91,*,iostat=eof) k_p 
       if (eof < 0) exit
-      read (101,*,iostat=eof) lambda0 
+      read (91,*,iostat=eof) lambda0 
       if (eof < 0) exit
-      read (101,*,iostat=eof) lambda1
+      read (91,*,iostat=eof) lambda1
       if (eof < 0) exit
-      read (101,*,iostat=eof) lambda2 
+      read (91,*,iostat=eof) lambda2 
       if (eof < 0) exit
-      read (101,*,iostat=eof) p_n
+      read (91,*,iostat=eof) p_n
       if (eof < 0) exit
-      read (101,*,iostat=eof) chla_subco
+      read (91,*,iostat=eof) chla_subco
       if (eof < 0) exit
       exit
       end do
@@ -158,7 +158,7 @@
         rhoq = rhoq / 24.
       end if
 
-      close (101)
+      close (91)
       return
  5100 format (a)
       end

--- a/src/rewind_init.f
+++ b/src/rewind_init.f
@@ -450,9 +450,9 @@
        !!precipitation
        do idum = 1, nrgage
         if (rfile(idum) /= '             ') then
-          rewind (unit=100+idum)
+          rewind (unit=1000+idum)
           do ii = 1, 4
-            read (100+idum,5000) titldum
+            read (1000+idum,5000) titldum
           end do
         end if
        end do


### PR DESCRIPTION
According to the fortran 90 standard, unit number in the range 100-102 included are assigned to stdin, stdout and stderr. They should not be used for "normal" files. The Cray compiler chokes on this. This solves issue #9  . 